### PR TITLE
Fix logic in HasAnyInternal by correcting pointer advancement and loop bounds for sorted list intersection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed GameplayTags not loading from StreamingAssets on Android (APK/AAB)
+- Fixed GameplayTags not loading from StreamingAssets on WebGL
 
 ## [0.1.0-beta.8] - 2025-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed GameplayTags not loading from StreamingAssets on Android (APK/AAB)
+
 ## [0.1.0-beta.8] - 2025-09-22
 
 ### Fixed

--- a/Runtime/BuildGameplayTagSource.cs
+++ b/Runtime/BuildGameplayTagSource.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using UnityEngine;
+using UnityEngine.Networking;
 
 namespace BandoWare.GameplayTags
 {
@@ -12,8 +13,11 @@ namespace BandoWare.GameplayTags
       {
          try
          {
-            using FileStream file = File.OpenRead(Path.Combine(Application.streamingAssetsPath, "GameplayTags"));
-            using BinaryReader reader = new(file);
+            string path = Path.Combine(Application.streamingAssetsPath, "GameplayTags");
+            byte[] data = LoadData(path);
+
+            using MemoryStream memoryStream = new(data);
+            using BinaryReader reader = new(memoryStream);
 
             while (reader.BaseStream.Position != reader.BaseStream.Length)
             {
@@ -25,6 +29,48 @@ namespace BandoWare.GameplayTags
          {
             Debug.LogError($"Failed to load gameplay tags from StreamingAssets: {e.Message}");
          }
+      }
+
+      private byte[] LoadData(string dataPath)
+      {
+         return Application.platform switch
+         {
+            RuntimePlatform.Android => LoadDataFromAndroidPackage(dataPath),
+            _ => LoadDataFromFile(dataPath),
+         };
+      }
+
+      private byte[] LoadDataFromAndroidPackage(string dataPath)
+      {
+         using UnityWebRequest request = UnityWebRequest.Get(dataPath);
+         UnityWebRequestAsyncOperation operation = request.SendWebRequest();
+         while (!operation.isDone) { }
+
+#if UNITY_2020_2_OR_NEWER
+         if (request.result != UnityWebRequest.Result.Success)
+#else
+         if (request.isNetworkError || request.isHttpError)
+#endif
+         {
+            if (request.responseCode == 404)
+               Debug.LogError($"GameplayTags file not found at path: {dataPath}");
+            else
+               Debug.LogError($"Failed to load gameplay tags from StreamingAssets: {request.error}");
+
+            return Array.Empty<byte>();
+         }
+
+         return request.downloadHandler.data;
+      }
+
+      private byte[] LoadDataFromFile(string path)
+      {
+         if (!File.Exists(path))
+         {
+            Debug.LogError($"GameplayTags file not found at path: {path}");
+            return Array.Empty<byte>();
+         }
+         return File.ReadAllBytes(path);
       }
    }
 }

--- a/Runtime/BuildGameplayTagSource.cs
+++ b/Runtime/BuildGameplayTagSource.cs
@@ -35,12 +35,13 @@ namespace BandoWare.GameplayTags
       {
          return Application.platform switch
          {
-            RuntimePlatform.Android => LoadDataFromAndroidPackage(dataPath),
+            RuntimePlatform.WebGLPlayer => LoadDataFromWebRequest(dataPath),
+            RuntimePlatform.Android => LoadDataFromWebRequest(dataPath),
             _ => LoadDataFromFile(dataPath),
          };
       }
 
-      private byte[] LoadDataFromAndroidPackage(string dataPath)
+      private byte[] LoadDataFromWebRequest(string dataPath)
       {
          using UnityWebRequest request = UnityWebRequest.Get(dataPath);
          UnityWebRequestAsyncOperation operation = request.SendWebRequest();

--- a/Runtime/GameplayTagContainerExtensionMethods.cs
+++ b/Runtime/GameplayTagContainerExtensionMethods.cs
@@ -47,24 +47,24 @@ namespace BandoWare.GameplayTags
          end = ~end;
 
          int j = 1;
-         int i = start + 1;
-         while (i < end && j < otherTagIndices.Count)
+         int i = start;
+         int otherLimit = otherTagIndices.Count - 1;
+
+         while (i < end && j < otherLimit)
          {
-            if (otherTagIndices[j] == tagIndices[i])
+            int tagVal = tagIndices[i];
+            int otherVal = otherTagIndices[j];
+
+            if (tagVal == otherVal)
                return true;
 
-            if (tagIndices[i] > otherTagIndices[j])
+            if (tagVal < otherVal)
             {
                i++;
-               continue;
             }
-
-            j++;
-            while (otherTagIndices[j] < tagIndices[i])
+            else
             {
                j++;
-               if (j == end)
-                  return false;
             }
          }
 


### PR DESCRIPTION
Fix a bug in HasAnyInternal where the intersection logic for sorted tag indices was incorrectly implemented. 

The previous code skipped potential matches by starting at the wrong index and used inverted pointer advancement logic, causing false negatives. The fix implements a standard two-pointer approach to correctly and efficiently identify overlapping tags.

Closes #19 