### PR TITLE
Automatically select the search field when opening a GameplayTag tree view & Keyboard shortcuts

### DIFF
--- a/Editor/GameplayTagContainerTreeView.cs
+++ b/Editor/GameplayTagContainerTreeView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
@@ -39,6 +40,17 @@ namespace BandoWare.GameplayTags.Editor
          GameplayTagTreeViewItem item = args.item as GameplayTagTreeViewItem;
          bool added;
 
+         
+         if (IsSelected(item.id) && Event.current.keyCode == KeyCode.Return && Event.current.type == EventType.KeyUp)
+         {
+            if (!item.IsIncluded || !item.IsExplicitIncluded)
+               AddTag(item.Tag);
+            else
+               RemoveTag(item.Tag);
+            
+            Repaint(); // Have to repaint or the Toggle GUI is not updated accordingly
+         }
+         
          EditorGUI.BeginChangeCheck();
          EditorGUI.showMixedValue = item.IsIncluded && !item.IsExplicitIncluded;
          added = EditorGUI.Toggle(rect, s_TempContent, item.IsIncluded);

--- a/Editor/GameplayTagTreeView.cs
+++ b/Editor/GameplayTagTreeView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
@@ -69,6 +70,15 @@ namespace BandoWare.GameplayTags.Editor
 
          GameplayTagTreeViewItem item = args.item as GameplayTagTreeViewItem;
 
+         
+         if (IsSelected(item.id) && Event.current.keyCode == KeyCode.Return && Event.current.type == EventType.KeyUp)
+         {
+            m_TagNameProperty.stringValue = item.Tag.Name;
+            m_TagNameProperty.serializedObject.ApplyModifiedProperties();
+         
+            m_OnSelectionChange?.Invoke();
+         }
+         
          if (GUI.Button(rect, s_TempContent, EditorStyles.label))
          {
             m_TagNameProperty.stringValue = item.Tag.Name;

--- a/Editor/GameplayTagTreeViewBase.cs
+++ b/Editor/GameplayTagTreeViewBase.cs
@@ -85,6 +85,7 @@ namespace BandoWare.GameplayTags.Editor
          Reload();
          
          m_SearchField.SetFocus();
+         m_SearchField.downOrUpArrowKeyPressed += SetFocusAndEnsureSelectedItem;
       }
 
       public override void OnGUI(Rect rect)

--- a/Editor/GameplayTagTreeViewBase.cs
+++ b/Editor/GameplayTagTreeViewBase.cs
@@ -83,6 +83,8 @@ namespace BandoWare.GameplayTags.Editor
          rowHeight = 24;
 
          Reload();
+         
+         m_SearchField.SetFocus();
       }
 
       public override void OnGUI(Rect rect)


### PR DESCRIPTION
This is a quality of life change 
Automatically select the search field when opening a GameplayTag tree view here, making it possible to directly type in a search instead of having to click on the field before searching
<img width="540" height="279" alt="image" src="https://github.com/user-attachments/assets/1d6a93b8-d03f-464d-b1a2-8c6b3aa1df10" />
